### PR TITLE
use jsoniter in time unmarshallers

### DIFF
--- a/time.go
+++ b/time.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"database/sql"
 	"database/sql/driver"
-	"encoding/json"
 	"fmt"
+	json "github.com/json-iterator/go"
 	"time"
 )
 

--- a/zero/time.go
+++ b/zero/time.go
@@ -3,7 +3,7 @@ package zero
 import (
 	"database/sql"
 	"database/sql/driver"
-	"encoding/json"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"time"
 )


### PR DESCRIPTION
- encoder/decoder registration is supported in
  jsoniter. This allows clients more flexibilty
  in time format unmarshalling.